### PR TITLE
Don't block clicks on elements inside the toggle

### DIFF
--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -285,7 +285,7 @@ limitations under the License.
          * @private
          */
         _clickHandler = function (event) {
-            var target = $(event.target),
+            var target = $(event.currentTarget),
                 topli = target.closest('.' + this.settings.topNavItemClass),
                 panel = target.closest('.' + this.settings.panelClass);
             if (topli.length === 1
@@ -630,7 +630,7 @@ limitations under the License.
          * @private
          */
         _mouseDownHandler = function (event) {
-            if ($(event.target).is(":focusable, ." + this.settings.panelClass)) {
+            if ($(event.target).is(this.settings.panelClass) || $(event.target).closest(":focusable").length) {
                 this.mouseFocused = true;
             }
             this.mouseTimeoutID = setTimeout(function () {


### PR DESCRIPTION
If another element inside the main links used for opening panels
were clicked, the event default would be prevented, and propogation
would be stopped.

This change allows clicks on child elements to be handled as normal.

* Expand the condition in _mouseDownHandler so mouseFocused is set to
  true for elements inside the links, as well as the links themselves.

* Use the currentTarget instead of the target in _clickHandler, so
  that it behaves as if the link was clicked, not a child element