### PR TITLE
Initialize npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/noahmanger/Accessible-Mega-Menu.git"
+    "url": "git+https://github.com/adobe-accessibility/Accessible-Mega-Menu.git"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Adobe Accessibility",
+  "license": "SEE LICENSE IN https://github.com/adobe-accessibility/Accessible-Mega-Menu/blob/master/LICENSE",
   "bugs": {
-    "url": "https://github.com/noahmanger/Accessible-Mega-Menu/issues"
+    "url": "https://github.com/adobe-accessibility/Accessible-Mega-Menu/issues"
   },
-  "homepage": "https://github.com/noahmanger/Accessible-Mega-Menu#readme"
+  "homepage": "https://github.com/adobe-accessibility/Accessible-Mega-Menu#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "accessible-mega-menu",
+  "version": "1.0.0",
+  "description": "Fork of Adobe's Accessible Mega Menu ",
+  "main": "js/jquery-accessibleMegaMenu.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/noahmanger/Accessible-Mega-Menu.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/noahmanger/Accessible-Mega-Menu/issues"
+  },
+  "homepage": "https://github.com/noahmanger/Accessible-Mega-Menu#readme"
+}


### PR DESCRIPTION
This adds a package.json that allows this to be installed over NPM. The `bugs`, `homepage`, `author` and `license` fields all point to this original repo. 
