### PR TITLE
Remove non-JS text from top of jquery-accessibleMegaMenu.js

### DIFF
--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -1,4 +1,4 @@
-https://github.com/JasonMSims/Accessible-Mega-Menu.git/*
+/*
 Copyright © 2013 Adobe Systems Incorporated.
 
 Licensed under the Apache License, Version 2.0 (the “License”);


### PR DESCRIPTION
The string "https://github.com/JasonMSims/Accessible-Mega-Menu.git" somehow got prepended onto this file's content in commit `3a530fea97495852513d5b2412378cbed6f1912f`, outside the /* ... */ comment.