### PR TITLE
Fix top-level link touch handling - Issue #32

### DIFF
--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -303,7 +303,7 @@ limitations under the License.
                         event.preventDefault();
                         event.stopPropagation();
                         this.justFocused = false;
-                    } else if (isTouch) {
+                    } else if (isTouch && !target.is("a")) {
                         event.preventDefault();
                         event.stopPropagation();
                         _togglePanel.call(this, event, target.hasClass(this.settings.openClass));


### PR DESCRIPTION
We shouldn't stop propagation of touch events when the item that has been touched is a link (<a> element) and the menu is already open.