### PR TITLE
Handle enter event on open top level link as escape event.

### DIFF
--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -589,11 +589,22 @@ limitations under the License.
                 break;
             case Keyboard.SPACE:
             case Keyboard.ENTER:
+                // Top level links.
                 if (isTopNavItem) {
                     event.preventDefault();
-                    _clickHandler.call(that, event);
-                } else {
-                    return true;
+                    // Handle enter event on open top level link as escape event.
+                    if (target.hasClass("open")) {
+                        this.mouseFocused = false;
+                        _togglePanel.call(that, event, true);
+                    }
+                    // Handle enter event on top level link as a click.
+                    else {
+                        _clickHandler.call(that, event);
+                    }
+                }
+                // Sub level links.
+                else {
+                  return true;
                 }
                 break;
             default:


### PR DESCRIPTION
This is working as desired on the demo site (https://adobe-accessibility.github.io/Accessible-Mega-Menu/). However in our testing the Enter key didn't close an expanded top level menu item.

This pull request explicitly asks the Enter event to activate the Escape event in this situation.