### PR TITLE
On enter activate top level link if it has no panel

### DIFF
--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -307,25 +307,33 @@ limitations under the License.
             var target = $(event.target).closest(':tabbable'),
                 topli = target.closest('.' + this.settings.topNavItemClass),
                 panel = target.closest('.' + this.settings.panelClass);
-            if (topli.length === 1
-                    && panel.length === 0
-                    && topli.find('.' + this.settings.panelClass).length === 1) {
+            // With panel.
+            if (topli.length === 1 && panel.length === 0 && topli.find('.' + this.settings.panelClass).length === 1) {
                 if (!target.hasClass(this.settings.openClass)) {
                     event.preventDefault();
                     event.stopPropagation();
                     _togglePanel.call(this, event);
                     this.justFocused = false;
-                } else {
+                }
+                else {
+                    // Handle focus event.
                     if (this.justFocused) {
                         event.preventDefault();
                         event.stopPropagation();
                         this.justFocused = false;
-                    } else if (isTouch || !isTouch && !this.settings.openOnMouseover) {
+                    }
+                    // Handle touch/click event.
+                    else if (isTouch || !isTouch && !this.settings.openOnMouseover) {
                         event.preventDefault();
                         event.stopPropagation();
                         _togglePanel.call(this, event, target.hasClass(this.settings.openClass));
                     }
                 }
+            }
+            // Without panel.
+            else if (topli.length === 1) {
+                // Ignore error "Cannot read property 'getCurrent' of undefined" in Chrome DevTools.
+                window.location.href = target.attr("href");
             }
         };
 
@@ -411,7 +419,7 @@ limitations under the License.
             target
                 .removeClass(this.settings.focusClass);
 
-            if (window.cvox) {
+            if (typeof window.cvox !== 'undefined' && window.cvox == true) {
                 // If ChromeVox is running...
                 that.focusTimeoutID = setTimeout(function () {
                     window.cvox.Api.getCurrentNode(function (node) {

--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -309,6 +309,7 @@ limitations under the License.
                 panel = target.closest('.' + this.settings.panelClass);
             // With panel.
             if (topli.length === 1 && panel.length === 0 && topli.find('.' + this.settings.panelClass).length === 1) {
+                // Handle click event.
                 if (!target.hasClass(this.settings.openClass)) {
                     event.preventDefault();
                     event.stopPropagation();
@@ -330,9 +331,8 @@ limitations under the License.
                     }
                 }
             }
-            // Without panel.
-            else if (topli.length === 1) {
-                // Ignore error "Cannot read property 'getCurrent' of undefined" in Chrome DevTools.
+            // Without panel on enter event.
+            else if (topli.length === 1 && panel.length === 0 && event.type == "keydown") {
                 window.location.href = target.attr("href");
             }
         };


### PR DESCRIPTION
In situations where a megamenu top level link doesn't have a corresponding sub panel, it would be better behaviour to allow an in focus top level link to go to that URL on pressing the enter key.