### PR TITLE
Fix mistargeting of topnav link when no panel

### DIFF
--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -822,8 +822,8 @@ limitations under the License.
                     var topnavitemlink, topnavitempanel;
                     topnavitem = $(topnavitem);
                     topnavitem.addClass(settings.topNavItemClass);
-                    topnavitemlink = topnavitem.find(":tabbable:first");
-                    topnavitempanel = topnavitem.children(":not(:tabbable):last");
+                    topnavitemlink = topnavitem.find("a");
+                    topnavitempanel = topnavitem.find('.' + settings.panelClass);
                     _addUniqueId.call(that, topnavitemlink);
                     if (topnavitempanel.length) {
                         _addUniqueId.call(that, topnavitempanel);


### PR DESCRIPTION
When a megamenu doesn't have a sub panel, the current selectors get confused. The selector for `topnavitempanel` will select the top level link instead and add its sub panel classes to it. This pull request more specifically targets top level link and its panel.

While the megamenu still works when panel attributes are added top level link, it breaks VoiceOver on iOS. In mobile when using VoiceOver and you expand the megamenu by toggling the menu button, you will then be unable to swipe to the navigation links. "Swipe" in this context refers to a touch gesture that tabs to the next item. This is because those sub panel attributes make the top level link invisible to VoiceOver (aria-hidden="true", "aria-expanded="false", role="region").
